### PR TITLE
use the correct initializer for the final layer of class_net 

### DIFF
--- a/efficientdet/efficientdet_arch.py
+++ b/efficientdet/efficientdet_arch.py
@@ -38,6 +38,12 @@ from backbone import efficientnet_builder
 
 
 ################################################################################
+
+# This constant is explained on page 5 of the Focal Loss paper
+FIANL_CONV_INITIALIZER = tf.constant_initializer(
+    -np.log((1 - 0.01) / 0.01))
+
+
 def freeze_vars(variables, pattern):
   """Removes backbone+fpn variables from the input.
 
@@ -276,7 +282,7 @@ def class_net(images,
       images,
       num_classes * num_anchors,
       kernel_size=3,
-      bias_initializer=tf.constant_initializer(-np.log((1 - 0.01) / 0.01)),
+      bias_initializer=FIANL_CONV_INITIALIZER,
       padding='same',
       name='class-predict')
   return classes

--- a/efficientdet/keras/efficientdet_arch_keras.py
+++ b/efficientdet/keras/efficientdet_arch_keras.py
@@ -6,7 +6,7 @@ from absl import logging
 import hparams_config
 import keras.utils_keras
 import utils
-from efficientdet_arch import build_backbone, build_feature_network
+import efficientdet_arch
 
 
 class ClassNet(tf.keras.layers.Layer):
@@ -94,7 +94,7 @@ class ClassNet(tf.keras.layers.Layer):
                 data_format=self.data_format,
                 kernel_size=3,
                 activation=None,
-                bias_initializer=tf.zeros_initializer(),
+                bias_initializer=efficientdet_arch.FIANL_CONV_INITIALIZER,
                 padding='same',
                 name=f'{self.name}/class-predict')
 
@@ -105,7 +105,7 @@ class ClassNet(tf.keras.layers.Layer):
                 data_format=self.data_format,
                 kernel_size=3,
                 activation=None,
-                bias_initializer=tf.zeros_initializer(),
+                bias_initializer=efficientdet_arch.FIANL_CONV_INITIALIZER,
                 padding='same',
                 name=f'{self.name}/class-predict')
 
@@ -373,12 +373,12 @@ def efficientdet(features, model_name=None, config=None, **kwargs):
   logging.info(config)
 
   # build backbone features.
-  features = build_backbone(features, config)
+  features = efficientdet_arch.build_backbone(features, config)
   logging.info('backbone params/flops = {:.6f}M, {:.9f}B'.format(
       *utils.num_params_flops()))
 
   # build feature network.
-  fpn_feats = build_feature_network(features, config)
+  fpn_feats = efficientdet_arch.build_feature_network(features, config)
   logging.info('backbone+fpn params/flops = {:.6f}M, {:.9f}B'.format(
       *utils.num_params_flops()))
 

--- a/efficientdet/keras/efficientdet_arch_keras_test.py
+++ b/efficientdet/keras/efficientdet_arch_keras_test.py
@@ -122,10 +122,10 @@ class EfficientDetNamesTest(tf.test.TestCase):
                     image_size=512)
         return [n.name for n in tf.get_default_graph().as_graph_def().node]
 
-
-    def test_efficientdet_d0(self):
-        self.assertContainsSubset(self.build_model(False),
-                                 self.build_model(True))
+    def test_graph_node_name_compatibility(self):
+        legacy_names = self.build_model(False)
+        keras_names = self.build_model(True)
+        self.assertContainsSubset(keras_names, legacy_names)
 
 
 class EfficientDetArchPrecisionTest(tf.test.TestCase):


### PR DESCRIPTION
Hi @VicariNishimura  This might fix that test case that was failing in https://github.com/google/automl/pull/376 . Please try it out.

It looks like the keras implementation was using the wrong initializer for the final classifier layer. Also, the keras implementation has slightly fewer operations than the legacy version. That is a good thing if they both produce the same results.

